### PR TITLE
Implemented rhyme command

### DIFF
--- a/commands/rhyme_command.rb
+++ b/commands/rhyme_command.rb
@@ -1,0 +1,50 @@
+module Commands
+  class RhymeCommand
+    class << self
+      include Discordrb::Webhooks
+
+      def name
+        :rhyme
+      end
+
+      def attributes
+        {
+          min_args: 1,
+          usage: 'rhyme term',
+          description: 'Return a list of rhymes for a term.'
+        }
+      end
+
+      def command(event, *term)
+        return if event.from_bot?
+
+        request = 'https://api.datamuse.com/words?rel_rhy=' << term[0]
+        response = RestClient.get(request)
+        body = JSON.parse response
+
+        groups = body.group_by { |word| word['numSyllables'] }
+
+        if groups.empty?
+          event << 'No synonyms for the word ' << term[0] << ' were found'
+        end
+
+        groups_sorted = groups.sort_by { |num_syllables| num_syllables }
+        embed_fields = groups_sorted.map do |(num_syllables, syllables)|
+          EmbedField.new(
+            name: "Syllables: #{num_syllables}",
+            value: syllables
+                .sort_by { |group| group['score'] }
+                .map { |group| group['word'] }
+                .join(', ')
+          )
+        end
+
+        embed = Embed.new(
+          title: 'Words that rhyme with ' << term[0],
+          fields: embed_fields
+        )
+        event.respond nil, false, embed
+      end
+    end
+  end
+end

--- a/commands/synonym_command.rb
+++ b/commands/synonym_command.rb
@@ -1,0 +1,41 @@
+module Commands
+  class SynonymCommand
+    class << self
+      include Discordrb::Webhooks
+
+      def name
+        :synonym
+      end
+
+      def attributes
+        {
+          min_args: 1,
+          usage: 'synonym term',
+          description: 'Return a list of synonyms for a term.'
+        }
+      end
+
+      def command(event, *term)
+        return if event.from_bot?
+
+        request = 'https://api.datamuse.com/words?rel_syn=' << term[0]
+        response = RestClient.get(request)
+        body = JSON.parse response
+
+        wordset = body.sort { |word| word['score'] }
+        words = body.map { |word| word['word'] }
+
+        if words.empty?
+          event << 'No synonyms for the word were found'
+          return
+        end
+
+        embed = Embed.new(
+          title: 'Synonyms for ' << term[0],
+          description: words.join(', ')
+        )
+        event.respond nil, false, embed
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rhyme command returns a set of words that rhyme with a given term, divided into groups by syllable count. Very useful, very cool.

<a href="https://gitpod.io/#https://github.com/HorizonShadow/YuelaBot/pull/122"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Kamilczak020/YuelaBot.git/142a07d2032f6d2471fe9289a96061f479ed6ba6.svg" /></a>

